### PR TITLE
explicitly require java 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
 		<slf4j.version>1.6.4</slf4j.version>
 	</properties>
 


### PR DESCRIPTION
Testing of 1.0.1 worked,

Here's a small patch to the pom file that explicitly set 1.7 as the java version. I branched from the 1.0.1 tag in your repo
