### PR TITLE
Allow "Red" environments to replace other "Red" environments

### DIFF
--- a/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/env/CreateEnvironmentMojo.java
+++ b/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/env/CreateEnvironmentMojo.java
@@ -219,6 +219,17 @@ public class CreateEnvironmentMojo extends AbstractNeedsEnvironmentMojo {
   boolean waitForReady;
 
   /**
+   * <p>If waiting for the environment to become ready, this indicates wether or not we require the Green health checks to pass.</p>
+   *
+   * <p>One reason to avoid such a requirement is if we are frantically replacing one failed environment with another one trying to get a ring of interdependant services to operate.</p>
+   *
+   * <p>Optional, but usually true. Under normal circumstances we *only* want to swap in a healthy service.</p>
+   */
+  @Parameter(property = "beanstalk.mustBeHealthy", defaultValue = "true")
+  boolean mustBeHealthy;
+
+
+  /**
    * <p>Environment Tier Name (defaults to "WebServer")</p>
    */
   @Parameter(property = "beanstalk.environmentTierName", defaultValue = "WebServer")
@@ -302,7 +313,7 @@ public class CreateEnvironmentMojo extends AbstractNeedsEnvironmentMojo {
       WaitForEnvironmentContext ctx = new WaitForEnvironmentContextBuilder()//
           .withEnvironmentRef(result.getEnvironmentId())//
           .withApplicationName(result.getApplicationName())//
-          .withHealth("Green")//
+          .withHealth((mustBeHealthy?"Green":null))//
           .withStatusToWaitFor("Ready")//
           .build();
 


### PR DESCRIPTION
Intended to allow updating environments with broken dependent services, or to support updating an environment with circular dependencies (all become green at once), etc.

Careful review would be appreciated, the changes are "straight forward", but untested.
