### PR TITLE
Fix unused update environment version

### DIFF
--- a/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/cmd/env/update/UpdateEnvironmentCommand.java
+++ b/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/cmd/env/update/UpdateEnvironmentCommand.java
@@ -62,6 +62,10 @@ public class UpdateEnvironmentCommand extends
         envTierType = "SQS/JSON";
       }
 
+      if (null != context.getEnvironmentTierVersion()) {
+        envTierVersion = context.getEnvironmentTierVersion();
+      }
+
       req.setTier(
           new EnvironmentTier().withName(context.getEnvironmentTierName()).withType(envTierType)
               .withVersion(envTierVersion));


### PR DESCRIPTION
Hello,

Since version 1.4.2, when we update an environment, this error occurs:

```
Caused by: com.amazonaws.AmazonServiceException: Cannot change environment tier (Service: AWSElasticBeanstalk; Status Code: 400; Error Code: InvalidParameterValue; Request ID:
```

Because the environment tier cannot be changed see [Update environment API](http://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_UpdateEnvironment.html).

If I add -X flag to the maven command, i see these argument in the AWS command:
```
Action=UpdateEnvironment&Version=2010-12-01&EnvironmentName=my-env&Tier.Name=WebServer&Tier.Type=Standard&Tier.Version=1.0&VersionLabel=...
```
The version "1.0" is not the one I have configured in my Maven pom.xml file:
```xml
<beanstalk.environmentTierName>WebServer</beanstalk.environmentTierName>
<beanstalk.environmentTierType>Standard</beanstalk.environmentTierType>
<beanstalk.environmentTierVersion> </beanstalk.environmentTierVersion>
```
The expected version is equal to a space. And not the hidden default value seen "1.0".

To quick-fix this the plugin use the configured version if it exists.


Note: 
I think the best way is to don't add any tier information if none is configured but this code seems always true (in file UpdateEnvironmentCommand.java just before the quick fix):
```java
if (null != context.getEnvironmentTierName()) {
```
because the environment tier name has a default value "WebServer" in the UpdateEnvironmentMojo.java file.

Maybe the environment tier may be deleted in the update environment query because it's impossible to change it in an update query (according to the AWS API documentation).