### PR TITLE
Allow multiple (comma separated) security groups in security group spec

### DIFF
--- a/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/AbstractBeanstalkMojo.java
+++ b/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/AbstractBeanstalkMojo.java
@@ -130,7 +130,7 @@ public abstract class AbstractBeanstalkMojo extends
         getLog().info("Probing security group '" + securityGroup + "'");
       }
 
-      Validate.isTrue(securityGroup.matches("^sg-\\p{XDigit}{8}$"),
+      Validate.isTrue(securityGroup.matches("^sg-\\p{XDigit}{8}(,sg-\\p{XDigit}{8})*$"),
                       "Invalid Security Group Spec: " + securityGroup);
 
       final AmazonEC2 ec2 = this.getClientFactory().getService(AmazonEC2Client.class);


### PR DESCRIPTION
When EB environment is configured with multiple security groups, copying the configuration to the new environment will not pass the validation. This fix modifies the regular expression to allow comma-separated security groups.