### PR TITLE
Supporting Java SE application for Maven plugin beanstalker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 .project
 .classpath
 .settings/
+.metadata/
 .idea
 *.iml
 
-src/
+./src/
 bin/
 target/
 

--- a/beanstalk-maven-plugin/pom.xml
+++ b/beanstalk-maven-plugin/pom.xml
@@ -27,6 +27,12 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.zeroturnaround</groupId>
+			<artifactId>zt-zip</artifactId>
+			<version>1.8</version>
+			<type>jar</type>
+		</dependency>
+		<dependency>
 			<groupId>br.com.ingenieux</groupId>
 			<artifactId>beanstalker-common</artifactId>
 		</dependency>

--- a/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/bundle/AbstractUploadSourceBundleMojo.java
+++ b/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/bundle/AbstractUploadSourceBundleMojo.java
@@ -1,0 +1,133 @@
+package br.com.ingenieux.mojo.beanstalk.bundle;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import br.com.ingenieux.mojo.aws.util.BeanstalkerS3Client;
+import br.com.ingenieux.mojo.beanstalk.AbstractBeanstalkMojo;
+
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+
+/**
+ * Uploads a packed war/zip file to Amazon S3 for further Deployment.
+ *
+ * @since 0.1.0
+ */
+public abstract class AbstractUploadSourceBundleMojo extends AbstractBeanstalkMojo {
+  /**
+   * S3 Bucket
+   */
+  @Parameter(property = "beanstalk.s3Bucket", defaultValue = "${project.groupId}.${project.artifactId}")
+  String s3Bucket;
+
+  /**
+   * S3 Key
+   */
+  @Parameter(property = "beanstalk.s3Key",
+             defaultValue = "${project.artifactId}/${project.build.finalName}.${project.packaging}",
+             required = true)
+  String s3Key;
+
+  /**
+   * <p> Should we do a multipart upload? Defaults to false </p> <p> Enable when you want to be
+   * charged slightly less :) </p>
+   */
+  @Parameter(property = "beanstalk.multipartUpload", defaultValue = "false")
+  boolean multipartUpload;
+
+  /**
+   * Artifact to Deploy
+   */
+  @Parameter(property = "beanstalk.artifactFile",
+             defaultValue="${project.build.directory}/${project.build.finalName}.${project.packaging}",
+             required = true)
+  File artifactFile;
+
+  /**
+   * Silent Upload?
+   */
+  @Parameter(property = "beanstalk.silentUpload", defaultValue = "false")
+  boolean silentUpload = false;
+
+  /**
+   * Version Label to use. Defaults to Project Version
+   */
+  @Parameter(property = "beanstalk.versionLabel", required = true)
+  String versionLabel;
+
+  @Parameter(defaultValue = "${project}")
+  MavenProject project;
+
+  protected Object executeInternal() throws Exception {
+    File toBeUploaded = getSourceBundle();
+    String path = toBeUploaded.getPath();
+
+    if (!(path.endsWith(".war") || path.endsWith(".jar") || path.endsWith(".zip"))) {
+      getLog().warn("Not a war/jar/zip file. Skipping");
+
+      return null;
+    }
+
+    if (!toBeUploaded.exists()) {
+      throw new MojoFailureException(
+          "Artifact File does not exist! (file=" + path + ")");
+    }
+
+    BeanstalkerS3Client client = new BeanstalkerS3Client(getAWSCredentials(),
+                                                         getClientConfiguration(), getRegion());
+
+    client.setMultipartUpload(multipartUpload);
+    client.setSilentUpload(silentUpload);
+
+    if (StringUtils.isBlank(s3Bucket)) {
+      getLog().info("S3 Bucket not defined.");
+      s3Bucket = getService().createStorageLocation().getS3Bucket();
+
+      getLog().info("Using defaults, like: " + s3Bucket);
+
+      project.getProperties().put("beanstalk.s3Bucket", s3Bucket);
+    }
+
+    getLog().info("Target Path: s3://" + s3Bucket + "/" + s3Key);
+    getLog().info("Uploading artifact file: " + path);
+
+    PutObjectResult result = client.putObject(new PutObjectRequest(s3Bucket, s3Key, toBeUploaded));
+
+    getLog().info("Artifact Uploaded");
+
+    project.getProperties().put("beanstalk.s3Key", s3Key);
+
+    return result;
+  }
+
+  /**
+   * The logic for retrieving source bundle file is different between Java Tomcat Web Applications
+   * and Java SE Applications. Subclass should override this method to retrieve the right source
+   * bundle file.
+   *
+   * @return the correct source bundle file.
+   * @throws Exception Exception might be thrown when creating source bundle file.
+   */
+  abstract protected File getSourceBundle() throws Exception;
+
+}

--- a/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/bundle/UploadJavaSourceBundleMojo.java
+++ b/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/bundle/UploadJavaSourceBundleMojo.java
@@ -1,0 +1,51 @@
+package br.com.ingenieux.mojo.beanstalk.bundle;
+
+import static br.com.ingenieux.mojo.beanstalk.util.SourceBundleUtil.PROCFILE;
+import static br.com.ingenieux.mojo.beanstalk.util.SourceBundleUtil.assemble;
+import static br.com.ingenieux.mojo.beanstalk.util.SourceBundleUtil.createSourceBundle;
+import static br.com.ingenieux.mojo.beanstalk.util.SourceBundleUtil.validateProcfile;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Upload a packed zip file from java SE project to Amazon S3 for further deployment.
+ *
+ */
+@Mojo(name="upload-java-source-bundle")
+public class UploadJavaSourceBundleMojo extends AbstractUploadSourceBundleMojo {
+    /**
+     * Project base directory
+     */
+    @Parameter(defaultValue = "${basedir}")
+    String basedir;
+
+    /**
+     * Zip file to be uploaded to S3 when the project is Java SE
+     */
+    @Parameter(property = "beanstalk.sourceBundleFile",
+            defaultValue = "${project.build.directory}/${project.build.finalName}.${project.packaging}.zip")
+    File sourceBundleFile;
+
+    @Parameter(defaultValue = "${project.build.directory}/beanstalker")
+    File beanstalkerFolder;
+
+    protected File getSourceBundle() throws IOException {
+
+        getLog().info(
+                "Creating source bundle for Java SE application to "
+                        + sourceBundleFile.getPath());
+
+        validateProcfile(PROCFILE);
+        assemble(artifactFile, beanstalkerFolder);
+        createSourceBundle(beanstalkerFolder, sourceBundleFile);
+
+        getLog().info("Source bundle file created");
+
+        return sourceBundleFile;
+    }
+}

--- a/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/bundle/UploadSourceBundleMojo.java
+++ b/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/bundle/UploadSourceBundleMojo.java
@@ -14,19 +14,9 @@ package br.com.ingenieux.mojo.beanstalk.bundle;
  * limitations under the License.
  */
 
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.PutObjectResult;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
-
 import java.io.File;
 
-import br.com.ingenieux.mojo.aws.util.BeanstalkerS3Client;
-import br.com.ingenieux.mojo.beanstalk.AbstractBeanstalkMojo;
+import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * Uploads a packed war file to Amazon S3 for further Deployment.
@@ -34,90 +24,10 @@ import br.com.ingenieux.mojo.beanstalk.AbstractBeanstalkMojo;
  * @since 0.1.0
  */
 @Mojo(name = "upload-source-bundle")
-public class UploadSourceBundleMojo extends AbstractBeanstalkMojo {
+public class UploadSourceBundleMojo extends AbstractUploadSourceBundleMojo {
 
-  /**
-   * S3 Bucket
-   */
-  @Parameter(property = "beanstalk.s3Bucket")
-  String s3Bucket;
-
-  /**
-   * S3 Key
-   */
-  @Parameter(property = "beanstalk.s3Key",
-             defaultValue = "${project.artifactId}/${project.build.finalName}-${beanstalk.versionLabel}.${project.packaging}",
-             required = true)
-  String s3Key;
-
-  /**
-   * <p> Should we do a multipart upload? Defaults to true </p> <p> Disable when you want to be
-   * charged slightly less :) </p>
-   */
-  @Parameter(property = "beanstalk.multipartUpload", defaultValue = "true")
-  boolean multipartUpload = false;
-
-  /**
-   * Artifact to Deploy
-   */
-  @Parameter(property = "beanstalk.artifactFile",
-             defaultValue="${project.build.directory}/${project.build.finalName}.${project.packaging}",
-             required = true)
-  File artifactFile;
-
-  /**
-   * Silent Upload?
-   */
-  @Parameter(property = "beanstalk.silentUpload", defaultValue = "false")
-  boolean silentUpload = false;
-
-  /**
-   * Version Label to use. Defaults to Project Version
-   */
-  @Parameter(property = "beanstalk.versionLabel", required = true)
-  String versionLabel;
-
-  @Parameter(defaultValue = "${project}")
-  MavenProject project;
-
-  protected Object executeInternal() throws Exception {
-    String path = artifactFile.getPath();
-
-    if (!(path.endsWith(".war") || path.endsWith(".jar") || path.endsWith(".zip"))) {
-      getLog().warn("Not a war/jar/zip file. Skipping");
-
-      return null;
-    }
-
-    if (!artifactFile.exists()) {
-      throw new MojoFailureException(
-          "Artifact File does not exist! (file=" + path + ")");
-    }
-
-    BeanstalkerS3Client client = new BeanstalkerS3Client(getAWSCredentials(),
-                                                         getClientConfiguration(), getRegion());
-
-    client.setMultipartUpload(multipartUpload);
-    client.setSilentUpload(silentUpload);
-
-    if (StringUtils.isBlank(s3Bucket)) {
-      getLog().info("S3 Bucket not defined.");
-      s3Bucket = getService().createStorageLocation().getS3Bucket();
-
-      getLog().info("Using defaults, like: " + s3Bucket);
-
-      project.getProperties().put("beanstalk.s3Bucket", s3Bucket);
-    }
-
-    getLog().info("Target Path: s3://" + s3Bucket + "/" + s3Key);
-    getLog().info("Uploading artifact file: " + path);
-
-    PutObjectResult result = client.putObject(new PutObjectRequest(s3Bucket, s3Key, artifactFile));
-
-    getLog().info("Artifact Uploaded");
-
-    project.getProperties().put("beanstalk.s3Key", s3Key);
-
-    return result;
+  protected File getSourceBundle() {
+      return artifactFile;
   }
+
 }

--- a/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/util/SourceBundleUtil.java
+++ b/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/util/SourceBundleUtil.java
@@ -1,0 +1,118 @@
+package br.com.ingenieux.mojo.beanstalk.util;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.FileUtils;
+import org.zeroturnaround.zip.ZipUtil;
+
+public class SourceBundleUtil {
+    public static final String PROCFILE = "Procfile";
+    public static final String BUILDFILE = "Buildfile";
+    public static final String EBEXTENSION = ".ebextension";
+    public static final String DEFAULT_MAIN_JAR_APPLICATION_NAME = "web";
+
+    public static boolean validateProcfileLine(String line) {
+        final Pattern PROCFILE_PROCESS_LINE_PATTERN = Pattern
+                .compile("^[A-Za-z0-9_]+:\\s*.+$");
+        return PROCFILE_PROCESS_LINE_PATTERN.matcher(line).matches();
+    }
+
+    /**
+     * Inspect a file from given path to see if the file is Procfile
+     * @param procfilePath given file path
+     * @throws IOException
+     * @throws IllegalArgumentException if the given file doesn't satisfy Procfile format
+     */
+    public static void validateProcfile(String procfilePath) throws IOException {
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(procfilePath));
+            String line = br.readLine();
+            int lineNo = 1;
+            while (line != null) {
+                if (!validateProcfileLine(line)) {
+                    throw new IllegalArgumentException(
+                            "Procfile doesn't follow regular expression: ^[A-Za-z0-9_]+:\\s*.+$ in line "
+                                    + lineNo);
+                }
+                if (lineNo == 1 && !line.startsWith(DEFAULT_MAIN_JAR_APPLICATION_NAME + ":")) {
+                    throw new IllegalArgumentException(
+                            "The command that runs the main JAR in your application must be called web, "
+                            + "and it must be the first command listed in your Procfile.");
+                }
+                lineNo++;
+                line = br.readLine();
+            }
+            br.close();
+        } catch (FileNotFoundException e) {
+            // do nothing if file doesn't exist
+        }
+    }
+
+    /**
+     * Aggregate all the files/directories needed to designated folder.
+     *
+     * @param beanstalkerFolder The destination folder.
+     * @throws IOException In case IO errors happen when copying files.
+     * @throws FileNotFoundException In case the artifact jar file isn't found
+     */
+    public static void assemble(File jarFile, File beanstalkerFolder) throws IOException {
+        if (!jarFile.exists()) {
+            throw new FileNotFoundException(
+                          "Artifact File does not exist! (file=" + jarFile.getPath() + ")");
+        }
+        if (!beanstalkerFolder.exists()) {
+            beanstalkerFolder.mkdir();
+        } else {
+            FileUtils.deleteQuietly(beanstalkerFolder);
+        }
+        copyFileToDirectory(jarFile, beanstalkerFolder);
+        copyFileToDirectory(new File(PROCFILE), beanstalkerFolder);
+        copyFileToDirectory(new File(BUILDFILE), beanstalkerFolder);
+        copyFileToDirectory(new File(EBEXTENSION), beanstalkerFolder);
+    }
+
+    /**
+     * Copy the source file to the destination directory. The destination directory will be
+     * the parent directory of the newly copied file no matter it's a normal file or a directory.
+     *
+     * @param srcFile File or directory to be copied from
+     * @param destDir Destination directory
+     * @throws IOException IOException might be thrown while copying
+     */
+    private static void copyFileToDirectory(File srcFile, File destDir) throws IOException {
+        if (!srcFile.exists()) {
+            throw new FileNotFoundException("No source file found at (" + srcFile.getPath() + ")");
+        }
+        if (!destDir.exists() || !destDir.isDirectory()) {
+            throw new FileNotFoundException("No destination directory found at (" + destDir.getPath() + ")");
+        }
+        if (srcFile.isFile()) {
+            FileUtils.copyFileToDirectory(srcFile, destDir);
+        } else if (srcFile.isDirectory()) {
+            FileUtils.copyDirectoryToDirectory(srcFile, destDir);
+        }
+    }
+
+    /**
+     * Create source bundle zip file from the given folder.
+     *
+     * @param beanstalkerFolder The source directory folder.
+     * @param sourceBundleFile The target zip file to create
+     * @throws FileNotFoundException In case no source directory found
+     */
+    public static void createSourceBundle(File beanstalkerFolder,
+            File sourceBundleFile) throws FileNotFoundException {
+        if (!beanstalkerFolder.exists() || !beanstalkerFolder.isDirectory()) {
+            throw new FileNotFoundException("No source directory found at (" + beanstalkerFolder.getPath() + ")");
+        }
+        if (sourceBundleFile.exists()) {
+            FileUtils.deleteQuietly(sourceBundleFile);
+        }
+        ZipUtil.pack(beanstalkerFolder, sourceBundleFile);
+    }
+}

--- a/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/version/CreateApplicationVersionMojo.java
+++ b/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/version/CreateApplicationVersionMojo.java
@@ -63,7 +63,7 @@ public class CreateApplicationVersionMojo extends AbstractBeanstalkMojo {
   /**
    * S3 Bucket
    */
-  @Parameter(property = "beanstalk.s3Bucket", defaultValue = "${project.artifactId}",
+  @Parameter(property = "beanstalk.s3Bucket", defaultValue = "${project.groupId}.${project.artifactId}",
              required = true)
   String s3Bucket;
 
@@ -71,7 +71,7 @@ public class CreateApplicationVersionMojo extends AbstractBeanstalkMojo {
    * S3 Key
    */
   @Parameter(property = "beanstalk.s3Key",
-             defaultValue = "${project.artifactId}/${project.build.finalName}-${beanstalk.versionLabel}.${project.packaging}",
+             defaultValue = "${project.artifactId}/${project.build.finalName}.${project.packaging}",
              required = true)
   String s3Key;
 
@@ -122,21 +122,21 @@ public class CreateApplicationVersionMojo extends AbstractBeanstalkMojo {
 
   private boolean versionLabelExists() {
                 /*
-		 * Builds a request for this very specific version label
-		 */
+                 * Builds a request for this very specific version label
+                 */
     DescribeApplicationVersionsRequest davRequest = new DescribeApplicationVersionsRequest()
         .withApplicationName(applicationName).withVersionLabels(
             versionLabel);
 
-		/*
-		 * Sends the request
-		 */
+                /*
+                 * Sends the request
+                 */
     DescribeApplicationVersionsResult result = getService()
         .describeApplicationVersions(davRequest);
 
-		/*
-		 * Non-empty means the application version label *DOES* exist.
-		 */
+                /*
+                 * Non-empty means the application version label *DOES* exist.
+                 */
     return !result.getApplicationVersions().isEmpty();
   }
 }

--- a/beanstalk-maven-plugin/src/test/java/br/com/ingenieux/mojo/beanstalk/util/SourceBundleUtilTest.java
+++ b/beanstalk-maven-plugin/src/test/java/br/com/ingenieux/mojo/beanstalk/util/SourceBundleUtilTest.java
@@ -1,0 +1,70 @@
+package br.com.ingenieux.mojo.beanstalk.util;
+
+import static br.com.ingenieux.mojo.beanstalk.util.SourceBundleUtil.validateProcfileLine;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+@SuppressWarnings("deprecation")
+public class SourceBundleUtilTest {
+
+    @Test
+    public void validateProcfileLineTest() {
+        String correctLine = "web: java -jar server.jar -Xmms:256m";
+        String hypenLine = "web-app: java -jar foo.jar";
+        String noColonLine = "web, java -jar foo.jar";
+
+        Assert.assertTrue(validateProcfileLine(correctLine));
+        Assert.assertFalse(validateProcfileLine(hypenLine));
+        Assert.assertFalse(validateProcfileLine(noColonLine));
+    }
+
+    @Test
+    public void validateProcfileTest() {
+        String correctProcfileFormat =
+                "web: java -jar server.jar -Xmms:256m\n"
+                + "cache: java -jar mycache.jar\n"
+                + "web_foo: java -jar other.jar\n";
+        String webIsNotFirstLine =
+                "cache: java -jar mycache.jar\n"
+                + "web: java -jar server.jar -Xmms:256m\n"
+                + "web_foo: java -jar other.jar\n";
+        try {
+            File correctProcfile = createTempFileWithContent("foo", "bar", correctProcfileFormat);
+            correctProcfile.deleteOnExit();
+            SourceBundleUtil.validateProcfile(correctProcfile.getPath());
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        } catch (IllegalArgumentException e) {
+            fail("IllegalArgumentException thrown while Procfile's format is correct!");
+        }
+
+        try {
+            File webIsNotFirstLineFile = createTempFileWithContent("bar", "foo", webIsNotFirstLine);
+            webIsNotFirstLineFile.deleteOnExit();
+            SourceBundleUtil.validateProcfile(webIsNotFirstLineFile.getPath());
+            fail("IllegalArgumentException didn't throw while Procfile's format is incorrect!");
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (IllegalArgumentException e) {
+        }
+
+    }
+
+    private File createTempFileWithContent(String prefix, String suffix, String content) throws IOException {
+        File file = File.createTempFile(prefix, suffix);
+        BufferedWriter writer = new BufferedWriter(new FileWriter(file.getPath()));
+        writer.write(content);
+        writer.close();
+        return file;
+    }
+
+}


### PR DESCRIPTION
Hi,

I have implemented supporting Java SE Application deployment to beanstalk to beanstalker maven plugin. With just few configurations, custormers can deploy a Java SE application the same way to a Java Tomcat Web application using beanstalk:upload-java-source-bundle mojo. I am using the third-party zt-zip to handle the gzipping files.

I have refactored UploadSourceBundleMojo.java as creating AbstractUploadSourceBundleMojo to be the base class for the original UploadSourceBundleMojo.java and the new UploadJavaSourceBundleMojo.java. The current implementation only supports for simple Java SE project (include one and only one jar artifact and Procfile, Buildfile, .ebextension directory), and cannot help auto generate Procfile. If you have any question, feel free to ask me.