### PR TITLE
Tier not used during update process

### DIFF
--- a/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/cmd/env/update/UpdateEnvironmentCommand.java
+++ b/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/cmd/env/update/UpdateEnvironmentCommand.java
@@ -1,15 +1,12 @@
 package br.com.ingenieux.mojo.beanstalk.cmd.env.update;
 
-import com.amazonaws.services.elasticbeanstalk.model.EnvironmentTier;
+import br.com.ingenieux.mojo.beanstalk.AbstractBeanstalkMojo;
+import br.com.ingenieux.mojo.beanstalk.cmd.BaseCommand;
 import com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentRequest;
 import com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentResult;
-
 import org.apache.maven.plugin.AbstractMojoExecutionException;
 
 import java.util.Arrays;
-
-import br.com.ingenieux.mojo.beanstalk.AbstractBeanstalkMojo;
-import br.com.ingenieux.mojo.beanstalk.cmd.BaseCommand;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
@@ -54,22 +51,22 @@ public class UpdateEnvironmentCommand extends
       req.setEnvironmentId(context.environmentId);
     }
 
-    if (null != context.getEnvironmentTierName()) {
-      String envTierType = "Standard";
-      String envTierVersion = "1.0";
-
-      if ("Worker".equals(context.getEnvironmentTierName())) {
-        envTierType = "SQS/JSON";
-      }
-
-      if (null != context.getEnvironmentTierVersion()) {
-        envTierVersion = context.getEnvironmentTierVersion();
-      }
-
-      req.setTier(
-          new EnvironmentTier().withName(context.getEnvironmentTierName()).withType(envTierType)
-              .withVersion(envTierVersion));
-    }
+//    if (null != context.getEnvironmentTierName()) {
+//      String envTierType = "Standard";
+//      String envTierVersion = "1.0";
+//
+//      if ("Worker".equals(context.getEnvironmentTierName())) {
+//        envTierType = "SQS/JSON";
+//      }
+//
+//      if (null != context.getEnvironmentTierVersion()) {
+//        envTierVersion = context.getEnvironmentTierVersion();
+//      }
+//
+//      req.setTier(
+//          new EnvironmentTier().withName(context.getEnvironmentTierName()).withType(envTierType)
+//              .withVersion(envTierVersion));
+//    }
 
     if (null != context.optionSettings && 0 != context.optionSettings.length) {
       req.setOptionSettings(Arrays.asList(context.optionSettings));


### PR DESCRIPTION
As the documentation states
 "At this time, if you change the tier version, name, or type,
 AWS Elastic Beanstalk returns InvalidParameterValue error."

 So let's not do it at this time...

In this regard #81 was correct, but the whole block - at this time - is not necessary at all...

After removing it everything works just fine, no configuration entries necessary.