### PR TITLE
Adding javase application archetype.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 .project
 .classpath
 .settings/
+.metadata/
 .idea
 *.iml
 
-src/
 bin/
 target/
 

--- a/elasticbeanstalk-javase-archetype/pom.xml
+++ b/elasticbeanstalk-javase-archetype/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>beanstalker</artifactId>
+    <groupId>br.com.ingenieux</groupId>
+    <version>1.4.3-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>elasticbeanstalk-javase-archetype</artifactId>
+  <packaging>maven-archetype</packaging>
+
+  <scm>
+    <connection>scm:hg:http://bitbucket.org/aldrinleal/beanstalker</connection>
+    <developerConnection>scm:hg:https://bitbucket.org/aldrinleal/beanstalker</developerConnection>
+  </scm>
+
+  <description>A Maven Archetype Encompassing Jetty for Publishing Java SE Services on AWS' Elastic Beanstalk Service</description>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>**/pom.xml</include>
+        </includes>
+      </resource>
+    </resources>
+
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>false</filtering>
+      </testResource>
+    </testResources>
+
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.archetype</groupId>
+        <artifactId>archetype-packaging</artifactId>
+        <version>2.3</version>
+      </extension>
+    </extensions>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-archetype-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.5</version>
+        <configuration>
+          <escapeString>\</escapeString>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/elasticbeanstalk-javase-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/elasticbeanstalk-javase-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd" name="jettymaven"
+    xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <fileSets>
+    <fileSet filtered="true" packaged="true" encoding="UTF-8">
+      <directory>src/main/java</directory>
+      <includes>
+        <include>**/*.java</include>
+      </includes>
+    </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/main/resources</directory>
+      <includes>
+        <include>**/*.html</include>
+      </includes>
+    </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/main/assembly</directory>
+      <includes>
+        <include>**/*.xml</include>
+      </includes>
+    </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory></directory>
+      <includes>
+        <include>Buildfile</include>
+        <include>Procfile</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</archetype-descriptor>

--- a/elasticbeanstalk-javase-archetype/src/main/resources/archetype-resources/Procfile
+++ b/elasticbeanstalk-javase-archetype/src/main/resources/archetype-resources/Procfile
@@ -1,0 +1,4 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+web: java -jar ${artifactId}-${version}.jar

--- a/elasticbeanstalk-javase-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/elasticbeanstalk-javase-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,193 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '%' )
+#set( $symbol_escape = '\' )
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>\${groupId}</groupId>
+    <artifactId>\${artifactId}</artifactId>
+    <version>\${version}</version>
+    <packaging>jar</packaging>
+    <name>Java Sample Jetty App</name>
+
+    <properties>
+        <!-- You can use a later version if you are are using Java 8 -->
+        <jettyVersion>9.2.0.RC0</jettyVersion>
+        <mainApplication>\${package}.Application</mainApplication>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <beanstalk.versionLabel>v1</beanstalk.versionLabel>
+        <beanstalk.mainJar>\${project.build.finalName}.jar</beanstalk.mainJar>
+        <beanstalk.sourceBundle>\${project.build.finalName}.zip</beanstalk.sourceBundle>
+        <beanstalk.artifactFile>\${project.build.directory}/\${beanstalk.sourceBundle}</beanstalk.artifactFile>
+        <!-- The default bucket name is \${project.groupId} which is highly possible not available for use in S3. Make sure you
+             change to an available bucket name. -->
+        <beanstalk.s3Bucket>\${project.groupId}</beanstalk.s3Bucket>
+        <beanstalk.s3Key>\${project.artifactId}-\${project.version}-\${beanstalk.versionLabel}.zip</beanstalk.s3Key>
+        <beanstalk.solutionStack>64bit Amazon Linux 2015.09 v2.0.4 running Java 7</beanstalk.solutionStack>
+        <beanstalk.environmentName>\${project.artifactId}</beanstalk.environmentName>
+        <beanstalk.cnamePrefix>\${project.artifactId}</beanstalk.cnamePrefix>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>\${jettyVersion}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <!-- This must be set as false so as to override the original jar file. -->
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <archive>
+                                <manifest>
+                                    <mainClass>\${mainApplication}</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>package-zip</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>src/main/assembly/zip.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>br.com.ingenieux</groupId>
+                <artifactId>beanstalk-maven-plugin</artifactId>
+                <version>1.4.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.1</version>
+                <executions>
+                    <execution><goals><goal>java</goal></goals></execution>
+                </executions>
+                <configuration>
+                    <mainClass>\${mainApplication}</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.mortbay.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>\${jettyVersion}</version>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>deploy</id>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+                <maven.install.skip>true</maven.install.skip>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+            <build>
+                <defaultGoal>deploy</defaultGoal>
+                <plugins>
+                    <plugin>
+                        <groupId>br.com.ingenieux</groupId>
+                        <artifactId>beanstalk-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>fast-deploy</goal>
+                                    <goal>replace-environment</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skipEnvironmentUpdate>true</skipEnvironmentUpdate>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>fast-deploy</id>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+                <maven.install.skip>true</maven.install.skip>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+            <build>
+                <defaultGoal>deploy</defaultGoal>
+                <plugins>
+                    <plugin>
+                        <groupId>br.com.ingenieux</groupId>
+                        <artifactId>beanstalk-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>fast-deploy</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>s3-deploy</id>
+            <properties>
+                <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
+                <beanstalk.versionLabel>${maven.build.timestamp}</beanstalk.versionLabel>
+                <maven.test.skip>true</maven.test.skip>
+                <maven.install.skip>true</maven.install.skip>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>br.com.ingenieux</groupId>
+                        <artifactId>beanstalk-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>upload-source-bundle</goal>
+                                    <goal>create-application-version</goal>
+                                    <!-- replace to replace-environment or blue-green
+                                         if you want zero downtime or blue-green -->
+                                    <goal>put-environment</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/elasticbeanstalk-javase-archetype/src/main/resources/archetype-resources/src/main/assembly/zip.xml
+++ b/elasticbeanstalk-javase-archetype/src/main/resources/archetype-resources/src/main/assembly/zip.xml
@@ -1,0 +1,35 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.${version}"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.${version} http://maven.apache.org/xsd/assembly-1.${version}.xsd">
+    <id>build-zip-file</id>
+    <baseDirectory>/</baseDirectory>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${symbol_dollar}{project.basedir}</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>Procfile</include>
+                <include>Buildfile</include>
+                <include>.ebextensions</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${symbol_dollar}{project.build.directory}</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+        <!-- Additional file sets you want to add in.
+        <fileSet>
+        </fileSet>
+        -->
+    </fileSets>
+</assembly>

--- a/elasticbeanstalk-javase-archetype/src/main/resources/archetype-resources/src/main/java/Application.java
+++ b/elasticbeanstalk-javase-archetype/src/main/resources/archetype-resources/src/main/java/Application.java
@@ -1,0 +1,72 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+public class Application extends AbstractHandler
+{
+    private static final int DEFAULT_PORT = 5000;
+    private static final int PAGE_SIZE = 3000;
+    private static final String INDEX_HTML = loadIndex();
+
+    private static String loadIndex() {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(Application.class.getResourceAsStream("/index.html")))) {
+            final StringBuilder page = new StringBuilder(PAGE_SIZE);
+            String line = null;
+
+            while ((line = reader.readLine()) != null) {
+                page.append(line);
+            }
+
+            return page.toString();
+        } catch (final Exception exception) {
+            return getStackTrace(exception);
+        }
+    }
+
+    private static String getStackTrace(final Throwable throwable) {
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter printWriter = new PrintWriter(stringWriter, true);
+        throwable.printStackTrace(printWriter);
+
+        return stringWriter.getBuffer().toString();
+    }
+    
+    private static int getPort() {
+        String port = System.getenv().get("PORT");
+        return port == null ? DEFAULT_PORT : Integer.parseInt(port);
+    }
+
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        response.setContentType("text/html;charset=utf-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+        baseRequest.setHandled(true);
+        response.getWriter().println(INDEX_HTML);
+    }
+
+    public static void main(String[] args) throws Exception
+    {
+        Server server = new Server(getPort());
+        server.setHandler(new Application());
+        server.start();
+        server.join();
+    }
+}

--- a/elasticbeanstalk-javase-archetype/src/main/resources/archetype-resources/src/main/resources/index.html
+++ b/elasticbeanstalk-javase-archetype/src/main/resources/archetype-resources/src/main/resources/index.html
@@ -1,0 +1,96 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Elastic Beanstalk</title>
+    <style>
+      body {
+        color: ${symbol_pound}ffffff;
+        font-family: Arial, sans-serif;
+        font-size:14px;
+        -moz-transition-property: text-shadow;
+        -moz-transition-duration: 4s;
+        -webkit-transition-property: text-shadow;
+        -webkit-transition-duration: 4s;
+        text-shadow: none;
+      }
+      body.blurry {
+        -moz-transition-property: text-shadow;
+        -moz-transition-duration: 4s;
+        -webkit-transition-property: text-shadow;
+        -webkit-transition-duration: 4s;
+        text-shadow: ${symbol_pound}fff 0px 0px 25px;
+      }
+      p {
+        color: ${symbol_pound}FF9933
+      }
+      a {
+        color: ${symbol_pound}F0FFFF;
+      }
+      .textColumn, .linksColumn {
+        padding: 2em;
+      }
+      .textColumn {
+        position: absolute;
+        top: 0px;
+        right: 50%;
+        bottom: 0px;
+        left: 0px;
+
+        text-align: right;
+        padding-top: 11em;
+        background-color: ${symbol_pound}F0FFFF;
+      }
+      .textColumn p {
+        width: 75%;
+        float:right;
+      }
+      .linksColumn {
+        position: absolute;
+        top:0px;
+        right: 0px;
+        bottom: 0px;
+        left: 50%;
+
+        background-color: ${symbol_pound}5C85D6;
+      }
+
+      h1 {
+        color: ${symbol_pound}3A599A;
+        font-size: 500%;
+        font-weight: normal;
+        margin-bottom: 0em;
+      }
+      h2 {
+        font-size: 200%;
+        font-weight: normal;
+        margin-bottom: 0em;
+      }
+      ul {
+        padding-left: 1em;
+        margin: 0px;
+      }
+      li {
+        margin: 1em 0em;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="textColumn">
+      <h1>Congratulations</h1>
+      <p>Your first AWS Elastic Beanstalk Java application is now running on your own dedicated environment in the AWS Cloud</p>
+    </div>
+    <div class="linksColumn">
+      <h2>What's Next?</h2>
+      <ul>
+        <li><a href="http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/Welcome.html">AWS Elastic Beanstalk overview</a></li>
+        <li><a href="http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.html">AWS Elastic Beanstalk concepts</a></li>
+        <li><a href="http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/java-se-platform.html">Using the AWS Elastic Beanstalk Java SE Platform</a></li>
+        <li><a href="http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.loggingS3.title.html">Working with Logs</a></li>
+      </ul>
+    </div>
+  </body>
+</html>
+

--- a/elasticbeanstalk-javase-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/elasticbeanstalk-javase-archetype/src/test/resources/projects/basic/archetype.properties
@@ -1,0 +1,5 @@
+#Sat Jan 16 15:33:22 PST 2016
+package=it.pkg
+version=0.1-SNAPSHOT
+groupId=archetype.it
+artifactId=basic

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <module>elasticbeanstalk-docker-dropwizard-webapp-archetype</module>
         <module>elasticbeanstalk-service-webapp-archetype</module>
         <module>elasticbeanstalk-wrapper-webapp-archetype</module>
+        <module>elasticbeanstalk-javase-archetype</module>
         <module>beanstalk-maven-plugin-it</module>
     </modules>
 


### PR DESCRIPTION
Hi @aldrinleal,

This is related to https://github.com/ingenieux/beanstalker/pull/83.

This archetype is for users' convenience to fast create java se applications to be deployed to AWS ElasticBeanstalk. The main contribution is having provided a easy way to generate a eb supported source bundle file as artifact for java se applications using maven-assembly-plugin. 

I am using the sample Jetty application provided by aws elasticbeanstlak at below link in this archetype. http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/samples/java-se-jetty-maven-v1.zip

After installing this archetype, you can simple create a java se application
`
mvn archetype:generate -DarchetypeGroupId=br.com.ingenieux -DarchetypeArtifactId=elasticbeanstalk-javase-archetype -DgroupId=your.prefered.group.id -DartifactId=artifact.id
`
and deploy it using
`
mvn deploy -Ps3-deploy
`

I will write a README file once you are ok with this pull request.