### PR TITLE
Issue 126 - Split securityGroup into a String array for AWS SDK api

### DIFF
--- a/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/AbstractBeanstalkMojo.java
+++ b/beanstalk-maven-plugin/src/main/java/br/com/ingenieux/mojo/beanstalk/AbstractBeanstalkMojo.java
@@ -133,9 +133,9 @@ public abstract class AbstractBeanstalkMojo extends AbstractAWSMojo<AWSElasticBe
       Validate.isTrue(securityGroup.matches("^sg-\\p{XDigit}{8,17}(,sg-\\p{XDigit}{8,17})*$"), "Invalid Security Group Spec: " + securityGroup);
 
       final AmazonEC2 ec2 = this.getClientFactory().getService(AmazonEC2Client.class);
-
+      
       final DescribeSecurityGroupsResult describeSecurityGroupsResult =
-          ec2.describeSecurityGroups(new DescribeSecurityGroupsRequest().withGroupIds(securityGroup));
+          ec2.describeSecurityGroups(new DescribeSecurityGroupsRequest().withGroupIds(securityGroup.split(",")));
 
       if (!describeSecurityGroupsResult.getSecurityGroups().isEmpty()) {
         final Predicate<SecurityGroup> predicate =


### PR DESCRIPTION
Hi, this change will correctly split the comma separated value of the securityGroup variable into a String array so that the AWS SDK won't throw an error. Related to Issue #126 